### PR TITLE
Add previous and last links to paginated responses

### DIFF
--- a/src/Yesod/Page.hs
+++ b/src/Yesod/Page.hs
@@ -20,6 +20,7 @@ where
 import Control.Monad (guard)
 import Data.Aeson
 import qualified Data.ByteString.Lazy as BSL
+import Data.Foldable (asum)
 import Data.Maybe (catMaybes, fromMaybe)
 import Data.Text (Text, pack, unpack)
 import Text.Read (readMaybe)
@@ -52,6 +53,8 @@ withPageLink makePosition fetchItems = do
     link = writeLinkHeader $ catMaybes
       [ Just $ renderedRouteLink "first" $ pageFirst page
       , renderedRouteLink "next" <$> pageNext page
+      , renderedRouteLink "previous" <$> pagePrevious page
+      , Just $ renderedRouteLink "last" $ pageLast page
       ]
 
   pageData page <$ addHeader "Link" link
@@ -76,24 +79,38 @@ withPage makePosition fetchItems = do
   -- We have to fetch page-size+1 items to know if there is a next page or not
   let (Limit realLimit) = cursorLimit cursor
   items <- fetchItems cursor { cursorLimit = Limit $ realLimit + 1 }
+  let page = case cursorPosition cursor of
+        First -> take realLimit items
+        Next{} -> take realLimit items
+        Previous{} -> takeEnd realLimit items
+        Last -> takeEnd realLimit items
 
   pure Page
-    { pageData = take realLimit items
+    { pageData = page
     , pageFirst = cursorRouteAtPosition cursor First
     , pageNext = do
       guard $ length items > realLimit
+      item <- lastMay page
       pure
         $ cursorRouteAtPosition cursor
         $ Next
-        $ makePosition
-        $ items
-        !! (realLimit - 1)
+        $ makePosition item
+    , pagePrevious = do
+      guard $ length items > realLimit
+      item <- headMay page
+      pure
+        $ cursorRouteAtPosition cursor
+        $ Previous
+        $ makePosition item
+    , pageLast = cursorRouteAtPosition cursor Last
     }
 
 data Page a = Page
   { pageData :: [a]
   , pageFirst :: RenderedRoute
   , pageNext :: Maybe RenderedRoute
+  , pagePrevious :: Maybe RenderedRoute
+  , pageLast :: RenderedRoute
   }
   deriving (Functor)
 
@@ -102,6 +119,8 @@ instance ToJSON a => ToJSON (Page a) where
     [ "data" .= pageData p
     , "first" .= pageFirst p
     , "next" .= pageNext p
+    , "previous" .= pagePrevious p
+    , "last" .= pageLast p
     ]
 
 -- | An encoding of the position in a page
@@ -115,7 +134,40 @@ data Cursor position = Cursor
   , cursorLimit :: Limit -- ^ The page size requested by the endpoint consumer
   }
 
-data Position position = First | Next position
+data Position position
+    = First
+    | Next position
+    | Previous position
+    | Last
+
+instance ToJSON position => ToJSON (Position position) where
+  toJSON = \case
+    First -> String "first"
+    Next p -> object ["next" .= p ]
+    Previous p -> object ["previous" .= p]
+    Last -> String "last"
+
+instance FromJSON position => FromJSON (Position position) where
+  parseJSON = \case
+    Null -> pure First
+    String t -> case t of
+        "first" -> pure First
+        "last" -> pure Last
+        _ -> invalidPosition
+    Object o -> do
+        mNext <- o .:? "next"
+        mPrevious <- o .:? "previous"
+        maybe invalidPosition pure $ asum
+         [ Next <$> mNext
+         , Previous <$> mPrevious
+         ]
+
+    _ -> invalidPosition
+   where
+    invalidPosition =
+      fail
+        $ "Position must be the String \"first\" or \"last\","
+        <> " or an Object with a \"next\" or \"previous\" key"
 
 newtype Limit = Limit { unLimit :: Int }
 
@@ -129,12 +181,8 @@ readLimit t = case readMaybe @Int $ unpack t of
 
 cursorRouteAtPosition
   :: ToJSON position => Cursor position -> Position position -> RenderedRoute
-cursorRouteAtPosition cursor = \case
-  First -> withPosition Nothing
-  Next p -> withPosition $ Just $ encodeText p
- where
-  withPosition mPosition =
-    updateQueryParameter "position" mPosition $ cursorRoute cursor
+cursorRouteAtPosition cursor position =
+  updateQueryParameter "position" (Just $ encodeText position) $ cursorRoute cursor
 
 parseCursorParams
   :: (MonadHandler m, FromJSON position, RenderRoute (HandlerSite m))
@@ -144,7 +192,7 @@ parseCursorParams = do
   position <- case mePosition of
     Nothing -> pure First
     Just (Left err) -> invalidArgs [pack err]
-    Just (Right p) -> pure $ Next p
+    Just (Right p) -> pure p
 
   limit <-
     either (\e -> invalidArgs [pack e]) pure
@@ -160,3 +208,17 @@ eitherDecodeText = eitherDecode . BSL.fromStrict . encodeUtf8
 
 encodeText :: ToJSON a => a -> Text
 encodeText = decodeUtf8 . BSL.toStrict . encode
+
+headMay :: [a] -> Maybe a
+headMay [] = Nothing
+headMay (x:_) = Just x
+
+lastMay :: [a] -> Maybe a
+lastMay [] = Nothing
+lastMay [x] = Just x
+lastMay (_:xs) = lastMay xs
+
+takeEnd :: Int -> [a] -> [a]
+takeEnd i xs = f xs (drop i xs)
+    where f (_:xs') (_:ys) = f xs' ys
+          f xs' _ = xs'


### PR DESCRIPTION
Extends our contract with callers to support links in either direction relative
to the "position" element.

To support this, we needed to:

- Extend `Position` to capture the new cases, and include them in responses,
  which also required a richer JSON encoding

  I chose to make the JSON somewhat human-friendly with simple `String` values
  for `first`/`last` and a single-key `Object` for `{next:}`/`{previous:}`.

  The resulting `Parser` is somewhat futzy, but the errors should be good.

  A (lower-syntax) alternative is to use `Generic` and let it be whatever it
  would be. But deriving `Generic` given the position type variable was an
  immediate hiccup, so I did not pursue this route.

- Alter the approach of dealing with the "limit + 1" [over-]query, which is used
  to see if there is a `Next` page.

  A sort of mirror-like logic is required for the `Previous` case, so extracting
  the page variable and moving to `lastMay` instead of `(!!)` highlights this.
  Viewing the resulting code (as opposed to a diff), could make that a little
  clearer to see.

- Update our test implementation to handle these cases, correctly

  This highlights the required discipline on the part of the callers:

  1. For `First`/`Next` they must use `(>.)`, `Asc` order, and not sort results
  2. For `Previous`/`Last` they must use `(<.)`, `Desc` order, and sort results

  We could build this in a way that the caller is not required to make these
  choices, but that would mean choosing concretely Persistent or Esqueleto,
  which is something we're deferring for now -- potentially to build as separate
  packages on top of this one.

**NOTE**: I re-implemented `safe:headMay`, `safe:lastMay`, and `extra:takeEnd`
rather than pulling in the dependencies. I'm happy to do that, if we decide we
don't care about that footprint.