### PR TITLE
Clean up project a bit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,3 +8,12 @@ workflows:
     jobs:
       - stack-build/build-test-lint:
           name: build
+
+          # Minor workaround for stack-build Orb expecting weeder-1 and invoking
+          # in a way that's incorrect with weeder-2. We'll run it ourselves for
+          # now.
+          weeder: false
+          after-dependencies:
+            - run: stack install --copy-compiler-tool weeder
+          after-test:
+            - run: stack exec weeder

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,10 @@
+version: 2.1
+
+orbs:
+  stack-build: pbrisbin/stack-build@3.0.1
+
+workflows:
+  commit:
+    jobs:
+      - stack-build/build-test-lint:
+          name: build

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,0 +1,2 @@
+- ignore: {name: "Redundant do", within: spec}
+- ignore: {name: "Reduce duplication", within: spec}

--- a/package.yaml
+++ b/package.yaml
@@ -7,50 +7,50 @@ maintainer: "evan@evan-borden.com"
 copyright: "2019 Evan Rutledge Borden"
 
 extra-source-files:
-- README.md
-- ChangeLog.md
+  - README.md
+  - ChangeLog.md
 
 description: Cursor based pagination for Yesod
 
 dependencies:
-- aeson
-- base >= 4.7 && < 5
-- bytestring
-- text
-- unliftio
-- yesod-core
+  - aeson
+  - base >= 4.7 && < 5
+  - bytestring
+  - text
+  - unliftio
+  - yesod-core
 
 library:
   source-dirs: src
   dependencies:
-  - containers
-  - http-link-header
-  - network-uri
+    - containers
+    - http-link-header
+    - network-uri
 
 tests:
   yesod-page-cursor-test:
     main: Spec.hs
     source-dirs: test
     ghc-options:
-    - -threaded
-    - -rtsopts
-    - -with-rtsopts=-N
+      - -threaded
+      - -rtsopts
+      - -with-rtsopts=-N
     dependencies:
-    - hspec
-    - hspec-expectations-lifted
-    - http-link-header
-    - http-types
-    - lens
-    - lens-aeson
-    - monad-logger
-    - mtl
-    - persistent
-    - persistent-sqlite
-    - persistent-template
-    - scientific
-    - time
-    - unliftio-core
-    - wai-extra
-    - yesod
-    - yesod-page-cursor
-    - yesod-test
+      - hspec
+      - hspec-expectations-lifted
+      - http-link-header
+      - http-types
+      - lens
+      - lens-aeson
+      - monad-logger
+      - mtl
+      - persistent
+      - persistent-sqlite
+      - persistent-template
+      - scientific
+      - time
+      - unliftio-core
+      - wai-extra
+      - yesod
+      - yesod-page-cursor
+      - yesod-test

--- a/package.yaml
+++ b/package.yaml
@@ -37,6 +37,7 @@ tests:
     - -with-rtsopts=-N
     dependencies:
     - hspec
+    - hspec-expectations-lifted
     - http-link-header
     - http-types
     - lens

--- a/package.yaml
+++ b/package.yaml
@@ -49,6 +49,7 @@ tests:
     - persistent-template
     - scientific
     - time
+    - unliftio-core
     - wai-extra
     - yesod
     - yesod-page-cursor

--- a/src/Yesod/Page.hs
+++ b/src/Yesod/Page.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE DeriveFunctor #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Yesod.Page
   ( withPageLink
@@ -23,9 +23,9 @@ import qualified Data.ByteString.Lazy as BSL
 import Data.Foldable (asum)
 import Data.Maybe (catMaybes, fromMaybe)
 import Data.Text (Text, pack, unpack)
-import Text.Read (readMaybe)
 import Data.Text.Encoding (decodeUtf8, encodeUtf8)
 import Network.HTTP.Link (writeLinkHeader)
+import Text.Read (readMaybe)
 import Yesod.Core
   ( HandlerSite
   , MonadHandler

--- a/stack.yaml
+++ b/stack.yaml
@@ -34,6 +34,10 @@ resolver: lts-16.10
 #  - wai
 packages:
   - .
+
+ghc-options:
+  "$locals": -fwrite-ide-info
+
 # Dependency packages to be pulled from upstream that are not in the resolver
 # using the same syntax as the packages field.
 # (e.g., acme-missiles-0.3)

--- a/stack.yaml
+++ b/stack.yaml
@@ -37,7 +37,6 @@ packages:
 
 ghc-options:
   "$locals": -fwrite-ide-info
-
 # Dependency packages to be pulled from upstream that are not in the resolver
 # using the same syntax as the packages field.
 # (e.g., acme-missiles-0.3)

--- a/stack.yaml
+++ b/stack.yaml
@@ -33,7 +33,7 @@ resolver: lts-16.10
 #  - auto-update
 #  - wai
 packages:
-- .
+  - .
 # Dependency packages to be pulled from upstream that are not in the resolver
 # using the same syntax as the packages field.
 # (e.g., acme-missiles-0.3)

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-13.16
+resolver: lts-16.10
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 497510
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/13/16.yaml
-    sha256: 3e56dd069db766f8e4c0a61ba49611e549c8b7757369fe1a063d1c33548790ac
-  original: lts-13.16
+    size: 532383
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/10.yaml
+    sha256: 469d781ab6d2a4eceed6b31b6e4ec842dcd3cd1d11577972e86902603dce24df
+  original: lts-16.10

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -204,31 +204,31 @@ getPaginated url params = request $ do
   setUrl url
   traverse_ (uncurry addGetParam) params
 
-assertDataKeys :: HasCallStack => [Scientific] -> SIO (YesodExampleData site) ()
+assertDataKeys :: HasCallStack => [Scientific] -> YesodExample site ()
 assertDataKeys expectedKeys = do
   statusIs 200
   keys <- getDataKeys
   keys `shouldBe` expectedKeys
 
-assertKeys :: HasCallStack => [Scientific] -> SIO (YesodExampleData site) ()
+assertKeys :: HasCallStack => [Scientific] -> YesodExample site ()
 assertKeys expectedKeys = do
   statusIs 200
   keys <- getKeys
   keys `shouldBe` expectedKeys
 
-getLink :: HasCallStack => Text -> SIO (YesodExampleData site) Text
+getLink :: HasCallStack => Text -> YesodExample site Text
 getLink rel =
   fromMaybe (error $ "no " <> unpack rel <> " in JSON response") <$> mayLink rel
 
 mayLink :: Text -> YesodExample site (Maybe Text)
 mayLink rel = withResponse $ pure . preview (key rel . _String) . simpleBody
 
-getLinkViaHeader :: HasCallStack => Text -> SIO (YesodExampleData site) Text
+getLinkViaHeader :: HasCallStack => Text -> YesodExample site Text
 getLinkViaHeader rel =
   fromMaybe (error $ "no " <> unpack rel <> " in Link header")
     <$> mayLinkViaHeader rel
 
-mayLinkViaHeader :: Text -> SIO (YesodExampleData site) (Maybe Text)
+mayLinkViaHeader :: Text -> YesodExample site (Maybe Text)
 mayLinkViaHeader rel = withResponse $ \resp -> pure $ do
   header <- lookup "Link" $ simpleHeaders resp
   parsed <- either (const Nothing) Just $ parseLinkHeader' $ decodeUtf8 header

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
@@ -6,8 +7,10 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Main (main, Widget, SomeAssignmentId, resourcesSimple) where
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -36,9 +36,9 @@ import Database.Persist
   , keyValueEntityToJSON
   , persistIdField
   , selectList
+  , (<.)
   , (==.)
   , (>.)
-  , (<.)
   )
 import Database.Persist.Sql (SqlBackend, runMigration)
 import Database.Persist.Sqlite (withSqliteConn)
@@ -110,7 +110,7 @@ getSomeLinkR :: Handler Value
 getSomeLinkR = makePaginationRoute withPageLink
 
 type Pagination m f a
-    = (Entity a -> Key a) -> (Cursor (Key a) -> m [Entity a]) -> m (f (Entity a))
+  = (Entity a -> Key a) -> (Cursor (Key a) -> m [Entity a]) -> m (f (Entity a))
 
 makePaginationRoute
   :: (Functor f, ToJSON (f Value))
@@ -372,7 +372,8 @@ mayLink rel = withResponse $ pure . preview (key rel . _String) . simpleBody
 
 getLinkViaHeader :: HasCallStack => Text -> SIO (YesodExampleData site) Text
 getLinkViaHeader rel =
-  fromMaybe (error $ "no " <> unpack rel <> " in Link header") <$> mayLinkViaHeader rel
+  fromMaybe (error $ "no " <> unpack rel <> " in Link header")
+    <$> mayLinkViaHeader rel
 
 mayLinkViaHeader :: Text -> SIO (YesodExampleData site) (Maybe Text)
 mayLinkViaHeader rel = withResponse $ \resp -> pure $ do

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -25,7 +25,7 @@ import GHC.Stack (HasCallStack)
 import Network.HTTP.Link
 import Network.HTTP.Types.Header (HeaderName)
 import Network.Wai.Test (simpleBody, simpleHeaders)
-import Test.Hspec (Spec, SpecWith, before, beforeAll_, describe, hspec, it)
+import Test.Hspec (Spec, SpecWith, beforeAll, before_, describe, hspec, it)
 import Test.Hspec.Expectations.Lifted (shouldBe, shouldReturn)
 import TestApp
 import Yesod.Core (RedirectUrl, Yesod)
@@ -177,7 +177,7 @@ spec = withApp $ do
       assertKeys [1, 2]
 
 withApp :: SpecWith (TestApp Simple) -> Spec
-withApp = before (testApp Simple id <$ wipeDB) . beforeAll_ setupDB
+withApp = beforeAll (testApp Simple id <$ setupDB) . before_ wipeDB
 
 setupDB :: IO ()
 setupDB = liftIO $ runDB $ runMigration migrateAll

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -22,8 +22,8 @@ import Database.Persist.Sql (SqlPersistT, runMigration)
 import GHC.Stack (HasCallStack)
 import Network.HTTP.Link
 import Network.Wai.Test (simpleBody, simpleHeaders)
-import Test.Hspec
-  (Spec, SpecWith, before, beforeAll_, describe, hspec, it, shouldBe)
+import Test.Hspec (Spec, SpecWith, before, beforeAll_, describe, hspec, it)
+import Test.Hspec.Expectations.Lifted (shouldBe, shouldReturn)
 import TestApp
 import Yesod.Test
 
@@ -46,8 +46,7 @@ spec = withApp $ do
       request $ do
         setUrl SomeR
         addGetParam "teacherId" "1"
-      mNext <- mayLink "next"
-      liftIO $ mNext `shouldBe` Nothing
+      mayLink "next" `shouldReturn` Nothing
 
     it "traverses a list with a next Cursor" $ do
       now <- liftIO getCurrentTime
@@ -72,8 +71,7 @@ spec = withApp $ do
         addGetParam "teacherId" "1"
         addGetParam "limit" "3"
       assertDataKeys [1, 2]
-      mNext <- mayLink "next"
-      liftIO $ mNext `shouldBe` Nothing
+      mayLink "next" `shouldReturn` Nothing
 
     it "finds a null next even with limit defaulted" $ do
       now <- liftIO getCurrentTime
@@ -82,8 +80,7 @@ spec = withApp $ do
       request $ do
         setUrl SomeR
         addGetParam "teacherId" "1"
-      mNext <- mayLink "next"
-      liftIO $ mNext `shouldBe` Nothing
+      mayLink "next" `shouldReturn` Nothing
 
     it "finds a null next even with page-aligned data" $ do
       now <- liftIO getCurrentTime
@@ -93,8 +90,7 @@ spec = withApp $ do
         setUrl SomeR
         addGetParam "teacherId" "1"
         addGetParam "limit" "2"
-      mNext <- mayLink "next"
-      liftIO $ mNext `shouldBe` Nothing
+      mayLink "next" `shouldReturn` Nothing
 
     it "finds a null next on the last page" $ do
       now <- liftIO getCurrentTime
@@ -105,8 +101,7 @@ spec = withApp $ do
         addGetParam "teacherId" "1"
         addGetParam "limit" "2"
       get =<< getLink "last"
-      mNext <- mayLink "next"
-      liftIO $ mNext `shouldBe` Nothing
+      mayLink "next" `shouldReturn` Nothing
 
     it "finds a null previous on the first page" $ do
       now <- liftIO getCurrentTime
@@ -116,8 +111,7 @@ spec = withApp $ do
         setUrl SomeR
         addGetParam "teacherId" "1"
         addGetParam "limit" "2"
-      mPrevious <- mayLink "previous"
-      liftIO $ mPrevious `shouldBe` Nothing
+      mayLink "previous" `shouldReturn` Nothing
 
     it "returns the same response for the same cursor" $ do
       now <- liftIO getCurrentTime
@@ -136,7 +130,7 @@ spec = withApp $ do
           getBody
       response1 <- go
       response2 <- go
-      liftIO $ response1 `shouldBe` response2
+      response1 `shouldBe` response2
 
     it "limits are optional" $ do
       now <- liftIO getCurrentTime
@@ -230,13 +224,13 @@ assertDataKeys :: HasCallStack => [Scientific] -> SIO (YesodExampleData site) ()
 assertDataKeys expectedKeys = do
   statusIs 200
   keys <- getDataKeys
-  liftIO $ keys `shouldBe` expectedKeys
+  keys `shouldBe` expectedKeys
 
 assertKeys :: HasCallStack => [Scientific] -> SIO (YesodExampleData site) ()
 assertKeys expectedKeys = do
   statusIs 200
   keys <- getKeys
-  liftIO $ keys `shouldBe` expectedKeys
+  keys `shouldBe` expectedKeys
 
 getLink :: HasCallStack => Text -> SIO (YesodExampleData site) Text
 getLink rel =

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,153 +1,29 @@
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE QuasiQuotes #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE UndecidableInstances #-}
 
-module Main (main, Widget, SomeAssignmentId, resourcesSimple) where
+module Main
+  ( main
+  )
+where
 
 import Control.Lens (preview, (^..))
-import Control.Monad.Logger (MonadLogger, NoLoggingT, runNoLoggingT)
-import Control.Monad.Reader (ReaderT, liftIO, replicateM_, runReaderT)
-import Data.Aeson (ToJSON, Value, defaultOptions, genericToJSON, toJSON)
+import Control.Monad.Logger (NoLoggingT, runNoLoggingT)
+import Control.Monad.Reader (ReaderT, liftIO, replicateM_)
 import Data.Aeson.Lens (key, _Array, _Number, _String)
 import Data.ByteString.Lazy (ByteString)
-import Data.List (find, sortOn)
-import Data.Maybe (catMaybes, fromMaybe)
+import Data.List (find)
+import Data.Maybe (fromMaybe)
 import Data.Scientific (Scientific)
 import Data.Text (Text, pack, unpack)
 import Data.Text.Encoding (decodeUtf8)
-import Data.Time (UTCTime, getCurrentTime)
-import Database.Persist
-  ( Entity(entityKey)
-  , Filter
-  , Key
-  , SelectOpt(..)
-  , deleteWhere
-  , insert
-  , keyValueEntityToJSON
-  , persistIdField
-  , selectList
-  , (<.)
-  , (==.)
-  , (>.)
-  )
+import Data.Time (getCurrentTime)
+import Database.Persist (Filter, deleteWhere, insert)
 import Database.Persist.Sql (SqlBackend, runMigration)
-import Database.Persist.Sqlite (withSqliteConn)
-import Database.Persist.TH
-  (mkMigrate, mkPersist, persistLowerCase, share, sqlSettings)
-import GHC.Generics (Generic)
 import GHC.Stack (HasCallStack)
 import Network.HTTP.Link
-import Network.HTTP.Types.Status (status400)
 import Network.Wai.Test (simpleBody, simpleHeaders)
 import Test.Hspec (hspec, shouldBe)
-import Yesod
-  ( MonadHandler
-  , MonadUnliftIO
-  , Yesod
-  , YesodPersist
-  , YesodPersistBackend
-  , lookupGetParam
-  , mkYesod
-  , parseRoutes
-  , renderRoute
-  , returnJson
-  , runDB
-  , sendResponseStatus
-  )
-import Yesod.Page
+import TestApp
 import Yesod.Test
-
-share [mkPersist sqlSettings, mkMigrate "migrateAll"] [persistLowerCase|
-SomeAssignment
-  teacherId Int
-  courseId Int
-  createdAt UTCTime
-  deriving (Generic)
-|]
-
-instance ToJSON SomeAssignment where
-  toJSON = genericToJSON defaultOptions
-
-data Simple = Simple
-
-instance Yesod Simple
-
-runDB' :: (MonadUnliftIO m, MonadLogger m) => ReaderT SqlBackend m a -> m a
-runDB' f = withSqliteConn ":test:" $ runReaderT f
-
-instance YesodPersist Simple where
-  type YesodPersistBackend Simple = SqlBackend
-  runDB = runDB'
-
-mkYesod "Simple" [parseRoutes|
-/some-route SomeR GET
-/some-route-link SomeLinkR GET
-|]
-
-optionalParam :: Read a => MonadHandler m => Text -> m (Maybe a)
-optionalParam name = fmap (read . unpack) <$> lookupGetParam name
-
-requireParam :: (MonadHandler m, Read a) => Text -> m a
-requireParam name = maybe badRequest pure =<< optionalParam name
- where
-  badRequest =
-    sendResponseStatus status400 $ "A " <> name <> " parameter is required."
-
-getSomeR :: Handler Value
-getSomeR = makePaginationRoute withPage
-
-getSomeLinkR :: Handler Value
-getSomeLinkR = makePaginationRoute withPageLink
-
-type Pagination m f a
-  = (Entity a -> Key a) -> (Cursor (Key a) -> m [Entity a]) -> m (f (Entity a))
-
-makePaginationRoute
-  :: (Functor f, ToJSON (f Value))
-  => Pagination Handler f SomeAssignment
-  -> Handler Value
-makePaginationRoute withPage' = do
-  teacherId <- requireParam "teacherId"
-  mCourseId <- optionalParam "courseId"
-
-  items <- withPage' entityKey $ \Cursor {..} ->
-    runDB $ sort cursorPosition <$> selectList
-      (catMaybes
-        [ Just $ SomeAssignmentTeacherId ==. teacherId
-        , (SomeAssignmentCourseId ==.) <$> mCourseId
-        , whereClause cursorPosition
-        ]
-      )
-      [LimitTo $ unLimit cursorLimit, orderBy cursorPosition]
-  returnJson $ keyValueEntityToJSON <$> items
- where
-  whereClause = \case
-    First -> Nothing
-    Next p -> Just $ persistIdField >. p
-    Previous p -> Just $ persistIdField <. p
-    Last -> Nothing
-
-  orderBy = \case
-    First -> Asc persistIdField
-    Next{} -> Asc persistIdField
-    Previous{} -> Desc persistIdField
-    Last -> Desc persistIdField
-
-  sort = \case
-    First -> id
-    Next{} -> id
-    Previous{} -> sortOn entityKey
-    Last -> sortOn entityKey
 
 main :: IO ()
 main = do

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -20,7 +20,7 @@ import Data.Text (Text, pack, unpack)
 import Data.Text.Encoding (decodeUtf8)
 import Data.Time (getCurrentTime)
 import Database.Persist (Filter, deleteWhere, insert)
-import Database.Persist.Sql (SqlPersistT, runMigration)
+import Database.Persist.Sql (SqlPersistT, insertMany_, runMigration)
 import GHC.Stack (HasCallStack)
 import Network.HTTP.Link
 import Network.Wai.Test (simpleBody, simpleHeaders)
@@ -193,7 +193,7 @@ deleteAssignments = deleteWhere ([] :: [Filter SomeAssignment])
 insertAssignments :: MonadIO m => Int -> SqlPersistT m ()
 insertAssignments n = do
   now <- liftIO getCurrentTime
-  replicateM_ n . insert $ SomeAssignment 1 2 now
+  insertMany_ $ replicate n $ SomeAssignment 1 2 now
 
 getPaginated
   :: (Yesod site, RedirectUrl site url)

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -51,7 +51,7 @@ spec = withApp $ do
 
     it "traverses a list with a next Cursor" $ do
       now <- liftIO getCurrentTime
-      runNoLoggingT . runDB' $ do
+      runDB $ do
         replicateM_ 12 . insert $ SomeAssignment 1 2 now
       request $ do
         setUrl SomeR
@@ -65,7 +65,7 @@ spec = withApp $ do
 
     it "finds a null next when no items are left" $ do
       now <- liftIO getCurrentTime
-      runNoLoggingT . runDB' $ do
+      runDB $ do
         replicateM_ 2 . insert $ SomeAssignment 1 2 now
       request $ do
         setUrl SomeR
@@ -76,7 +76,7 @@ spec = withApp $ do
 
     it "finds a null next even with limit defaulted" $ do
       now <- liftIO getCurrentTime
-      runNoLoggingT . runDB' $ do
+      runDB $ do
         replicateM_ 2 . insert $ SomeAssignment 1 2 now
       request $ do
         setUrl SomeR
@@ -85,7 +85,7 @@ spec = withApp $ do
 
     it "finds a null next even with page-aligned data" $ do
       now <- liftIO getCurrentTime
-      runNoLoggingT . runDB' $ do
+      runDB $ do
         replicateM_ 2 . insert $ SomeAssignment 1 2 now
       request $ do
         setUrl SomeR
@@ -95,7 +95,7 @@ spec = withApp $ do
 
     it "finds a null next on the last page" $ do
       now <- liftIO getCurrentTime
-      runNoLoggingT . runDB' $ do
+      runDB $ do
         replicateM_ 2 . insert $ SomeAssignment 1 2 now
       request $ do
         setUrl SomeR
@@ -106,7 +106,7 @@ spec = withApp $ do
 
     it "finds a null previous on the first page" $ do
       now <- liftIO getCurrentTime
-      runNoLoggingT . runDB' $ do
+      runDB $ do
         replicateM_ 2 . insert $ SomeAssignment 1 2 now
       request $ do
         setUrl SomeR
@@ -116,7 +116,7 @@ spec = withApp $ do
 
     it "returns the same response for the same cursor" $ do
       now <- liftIO getCurrentTime
-      runNoLoggingT . runDB' $ do
+      runDB $ do
         replicateM_ 5 . insert $ SomeAssignment 1 2 now
       request $ do
         setUrl SomeR
@@ -135,7 +135,7 @@ spec = withApp $ do
 
     it "limits are optional" $ do
       now <- liftIO getCurrentTime
-      runNoLoggingT . runDB' $ do
+      runDB $ do
         replicateM_ 5 . insert $ SomeAssignment 1 2 now
       request $ do
         setUrl SomeR
@@ -145,7 +145,7 @@ spec = withApp $ do
 
     it "parses optional params" $ do
       now <- liftIO getCurrentTime
-      runNoLoggingT . runDB' $ do
+      runDB $ do
         _ <- insert $ SomeAssignment 1 3 now
         replicateM_ 5 . insert $ SomeAssignment 1 2 now
       request $ do
@@ -157,7 +157,7 @@ spec = withApp $ do
 
     it "can link to first" $ do
       now <- liftIO getCurrentTime
-      runNoLoggingT . runDB' $ do
+      runDB $ do
         replicateM_ 6 . insert $ SomeAssignment 1 2 now
       request $ do
         setUrl SomeR
@@ -173,7 +173,7 @@ spec = withApp $ do
 
     it "can link to last" $ do
       now <- liftIO getCurrentTime
-      runNoLoggingT . runDB' $ do
+      runDB $ do
         replicateM_ 6 . insert $ SomeAssignment 1 2 now
       request $ do
         setUrl SomeR
@@ -189,7 +189,7 @@ spec = withApp $ do
 
     it "can traverse via Link" $ do
       now <- liftIO getCurrentTime
-      runNoLoggingT . runDB' $ do
+      runDB $ do
         replicateM_ 6 . insert $ SomeAssignment 1 2 now
       request $ do
         setUrl SomeLinkR

--- a/test/TestApp.hs
+++ b/test/TestApp.hs
@@ -1,0 +1,137 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module TestApp where
+
+import Control.Monad.Logger (MonadLogger)
+import Control.Monad.Reader (ReaderT, runReaderT)
+import Data.Aeson (ToJSON, Value, defaultOptions, genericToJSON, toJSON)
+import Data.List (sortOn)
+import Data.Maybe (catMaybes)
+import Data.Text (Text, unpack)
+import Data.Time (UTCTime)
+import Database.Persist
+  ( Entity(entityKey)
+  , Key
+  , SelectOpt(..)
+  , keyValueEntityToJSON
+  , persistIdField
+  , selectList
+  , (<.)
+  , (==.)
+  , (>.)
+  )
+import Database.Persist.Sql (SqlBackend)
+import Database.Persist.Sqlite (withSqliteConn)
+import Database.Persist.TH
+  (mkMigrate, mkPersist, persistLowerCase, share, sqlSettings)
+import GHC.Generics (Generic)
+import Network.HTTP.Types.Status (status400)
+import Yesod
+  ( MonadHandler
+  , MonadUnliftIO
+  , Yesod
+  , YesodPersist
+  , YesodPersistBackend
+  , lookupGetParam
+  , mkYesod
+  , parseRoutes
+  , renderRoute
+  , returnJson
+  , runDB
+  , sendResponseStatus
+  )
+import Yesod.Page
+
+share [mkPersist sqlSettings, mkMigrate "migrateAll"] [persistLowerCase|
+SomeAssignment
+  teacherId Int
+  courseId Int
+  createdAt UTCTime
+  deriving (Generic)
+|]
+
+instance ToJSON SomeAssignment where
+  toJSON = genericToJSON defaultOptions
+
+data Simple = Simple
+
+instance Yesod Simple
+
+runDB' :: (MonadUnliftIO m, MonadLogger m) => ReaderT SqlBackend m a -> m a
+runDB' f = withSqliteConn ":test:" $ runReaderT f
+
+instance YesodPersist Simple where
+  type YesodPersistBackend Simple = SqlBackend
+  runDB = runDB'
+
+mkYesod "Simple" [parseRoutes|
+/some-route SomeR GET
+/some-route-link SomeLinkR GET
+|]
+
+optionalParam :: Read a => MonadHandler m => Text -> m (Maybe a)
+optionalParam name = fmap (read . unpack) <$> lookupGetParam name
+
+requireParam :: (MonadHandler m, Read a) => Text -> m a
+requireParam name = maybe badRequest pure =<< optionalParam name
+ where
+  badRequest =
+    sendResponseStatus status400 $ "A " <> name <> " parameter is required."
+
+getSomeR :: Handler Value
+getSomeR = makePaginationRoute withPage
+
+getSomeLinkR :: Handler Value
+getSomeLinkR = makePaginationRoute withPageLink
+
+type Pagination m f a
+  = (Entity a -> Key a) -> (Cursor (Key a) -> m [Entity a]) -> m (f (Entity a))
+
+makePaginationRoute
+  :: (Functor f, ToJSON (f Value))
+  => Pagination Handler f SomeAssignment
+  -> Handler Value
+makePaginationRoute withPage' = do
+  teacherId <- requireParam "teacherId"
+  mCourseId <- optionalParam "courseId"
+
+  items <- withPage' entityKey $ \Cursor {..} ->
+    runDB $ sort cursorPosition <$> selectList
+      (catMaybes
+        [ Just $ SomeAssignmentTeacherId ==. teacherId
+        , (SomeAssignmentCourseId ==.) <$> mCourseId
+        , whereClause cursorPosition
+        ]
+      )
+      [LimitTo $ unLimit cursorLimit, orderBy cursorPosition]
+  returnJson $ keyValueEntityToJSON <$> items
+ where
+  whereClause = \case
+    First -> Nothing
+    Next p -> Just $ persistIdField >. p
+    Previous p -> Just $ persistIdField <. p
+    Last -> Nothing
+
+  orderBy = \case
+    First -> Asc persistIdField
+    Next{} -> Asc persistIdField
+    Previous{} -> Desc persistIdField
+    Last -> Desc persistIdField
+
+  sort = \case
+    First -> id
+    Next{} -> id
+    Previous{} -> sortOn entityKey
+    Last -> sortOn entityKey

--- a/weeder.dhall
+++ b/weeder.dhall
@@ -1,0 +1,3 @@
+{ roots = [ "^Main\\.main\$", "^Paths_.*", "^TestApp\\.get.*R\$" ]
+, type-class-roots = True
+}


### PR DESCRIPTION
Some things I noticed in previous PRs, separated into a behavior neutral set:

- 4ba3c52 Add CI
- dc6f2b3 Extract more conventional `yesod-test` helpers

  `getBody` existed but we now use it more consistently (rather than call
  `withResponse` and `simpleBody` in multiple places. `getHeader` is new, to
  align with that style of usage.

- d345fa4 Use `insertMany_` to speed up test setup
- c28d0e2 Use `YesodExample`, not `SIO`

  `SIO` is a bit of an implementation detail that may change. This also just
  reads better, IMO.

- b9af184 Extract request helper

  And add whitespace to indicate test phases.

- 5fa8f2f Re-use `runDB`
- 9e7bc4e Extract test-specific `runDB`
- 533fa3b Use lifted expectations

  This opens up `shouldReturn`, instead of bind and `shouldBe`

- a9eba66 Move to conventional `yesod-test` patterns

  Define `withApp` to setup a `TestApp`, and use normal `it`/`describe`.

- 39803e0 Extract `TestApp` to its own module
- 5fd157e Fix style

  Run brittany and stylish-haskell over `src/` and `test/`

- 8517a72 Update to latest Stack resolver