### PR TITLE
Correctly handle conditional previous-page link

### DIFF
--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -59,6 +59,28 @@ spec = withApp $ do
       get =<< getLink "next"
       assertDataKeys [9, 10, 11, 12]
 
+    it "traverses a list to next and previous" $ do
+      runDB $ insertAssignments 12
+
+      getPaginated SomeR [("teacherId", "1"), ("limit", "4")]
+
+      assertDataKeys [1, 2, 3, 4]
+      get =<< getLink "next"
+      assertDataKeys [5, 6, 7, 8]
+      get =<< getLink "previous"
+      assertDataKeys [1, 2, 3, 4]
+
+    it "correctly handles incomplete pages" $ do
+      runDB $ insertAssignments 3
+
+      getPaginated SomeR [("teacherId", "1"), ("limit", "2")]
+
+      assertDataKeys [1, 2]
+      get =<< getLink "next"
+      assertDataKeys [3]
+      get =<< getLink "previous"
+      assertDataKeys [1, 2]
+
     it "finds a null next when no items are left" $ do
       runDB $ insertAssignments 2
 


### PR DESCRIPTION
The handling of this was incorrect with regard to the extra item
indicating presence of a Next page or Previous page.

To work correctly, we need to switch on the current position a few times
to ensure that:

- The "extra" item existing is only used to indicate a Next page if we
  were "traveling in that direction". Otherwise, it should be used to
  indicate a Previous page existing

- Being on a First or Next page can know a-priori if there's a Previous
  page. Similarly, being on a Last or Previous page can know if there's
  a Next page -- checking for the "extra item" in either of these cases
  will give the wrong answer half the time.

Since the current test suite only ever checked for conditionality of a
Previous link from a Last page, it happened to work. The failing case
was discovered when trying to use this library in an app, via it's test
suite, and backfilled here.