### PR TITLE
Add defaultLimit :: Int argument to withPage[Link]

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ getSomeR = do
     Last -> reverse
 ```
 
-`cursorLastPosition` is configurable. A page sorted by `created_at` may look like:
+`cursorLastPosition` is configurable. A page sorted by `created_at` may look
+like:
 
 ```hs
 createdAtPage = PageConfig
@@ -84,7 +85,8 @@ getSortedSomeR = do
 
 ## Usage
 
-Paginated requests return a single page and a link with a cursor token to retrieve the next page.
+Paginated requests return a single page and a link with a cursor token to
+retrieve the next page.
 
 ```sh
 $ curl 'some-rest.com/endpoint?limit=3'

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ getSomeR = do
   let
     parseParams =
       (,) <$> Param.required "teacherId" <*> Param.optional "courseId"
-  page <- withPage entityPage parseParams $ \Cursor {..} -> do
+  page <- withPage 100 entityPage parseParams $ \Cursor {..} -> do
     let (teacherId, mCourseId) = cursorParams
     fmap (sort cursorPosition) . runDB $ selectList
       (catMaybes
@@ -51,7 +51,7 @@ createdAtPage = PageConfig
 getSortedSomeR :: Handler Value
 getSortedSomeR = do
   let parseParams = pure ()
-  page <- withPage createdAtPage parseParams $ \Cursor {..} -> do
+  page <- withPage 100 createdAtPage parseParams $ \Cursor {..} -> do
     fmap (sort cursorPosition) . runDB $ selectList
       (whereClause cursorPosition)
       [ LimitTo $ fromMaybe 100 cursorLimit

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -41,7 +41,7 @@ spec = withApp $ do
       getPaginated SomeR [("teacherId", "1"), ("limit", "-1")]
 
       statusIs 400
-      bodyContains "must be positive and non-zero"
+      bodyContains "must be a positive natural number"
 
     it "returns no cursor when there are no items" $ do
       getPaginated SomeR [("teacherId", "1")]

--- a/test/TestApp.hs
+++ b/test/TestApp.hs
@@ -97,7 +97,10 @@ getSomeLinkR :: Handler Value
 getSomeLinkR = makePaginationRoute withPageLink
 
 type Pagination m f a
-  = (Entity a -> Key a) -> (Cursor (Key a) -> m [Entity a]) -> m (f (Entity a))
+  = Limit
+  -> (Entity a -> Key a)
+  -> (Cursor (Key a) -> m [Entity a])
+  -> m (f (Entity a))
 
 makePaginationRoute
   :: (Functor f, ToJSON (f Value))
@@ -107,7 +110,7 @@ makePaginationRoute withPage' = do
   teacherId <- requireParam "teacherId"
   mCourseId <- optionalParam "courseId"
 
-  items <- withPage' entityKey $ \Cursor {..} ->
+  items <- withPage' 100 entityKey $ \Cursor {..} ->
     runDB $ sort cursorPosition <$> selectList
       (catMaybes
         [ Just $ SomeAssignmentTeacherId ==. teacherId

--- a/test/TestApp.hs
+++ b/test/TestApp.hs
@@ -97,7 +97,7 @@ getSomeLinkR :: Handler Value
 getSomeLinkR = makePaginationRoute withPageLink
 
 type Pagination m f a
-  = Limit
+  = Int
   -> (Entity a -> Key a)
   -> (Cursor (Key a) -> m [Entity a])
   -> m (f (Entity a))


### PR DESCRIPTION
Add ~~`defaultLimit :: Limit`~~ `defaultLimit :: Int` argument to `withPage[Link]`

Previously, we hard-coded 100 as a default limit, but the client application may need to specify a different default. ~~I added instances for `Eq`, `Show`, `Ord`, and `Num` for `Limit` since the constructor wasn't exported. It may make more sense to have a separate `newtype` like `DefaultLimit` to indicate that we're only specifying a fallback.~~

This is a breaking change.

**Edit**: `defaultLimit` is now of type `Int` so we can better validate it at runtime.