### PR TITLE
Fix test suite, build for stack, prepare release

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,10 @@
 
 None.
 
+## [v2.0.0.1](https://github.com/freckle/yesod-page-cursor/compare/v2.0.0.0...v2.0.0.1)
+
+- Fix test suite for new persistent
+
 ## [v2.0.0.0](https://github.com/freckle/yesod-page-cursor/compare/v1.0.0.1...v2.0.0.0)
 
 - Add `defaultLimit :: Int` argument to `withPage` and `withPageLink`

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,7 +12,6 @@ None.
 
 - Add `defaultLimit :: Int` argument to `withPage` and `withPageLink`
 
-
 ## [v1.0.0.1](https://github.com/freckle/yesod-page-cursor/compare/v1.0.0.0...v1.0.0.1)
 
 - Fix missing `previous` link in all but last page

--- a/package.yaml
+++ b/package.yaml
@@ -13,10 +13,10 @@ extra-source-files:
 description: Cursor based pagination for Yesod
 
 dependencies:
-  - aeson
+  - aeson < 1.6
   - base >= 4.7 && < 5
   - bytestring
-  - text
+  - text >= 1.2.3.2
   - unliftio
   - yesod-core
 
@@ -40,7 +40,7 @@ tests:
       - hspec-expectations-lifted
       - http-link-header
       - http-types
-      - lens
+      - lens < 4.20
       - lens-aeson
       - monad-logger
       - mtl
@@ -49,8 +49,8 @@ tests:
       - persistent-template
       - scientific
       - time
-      - unliftio-core
-      - wai-extra
+      - unliftio-core < 0.3
+      - wai-extra < 3.2
       - yesod
       - yesod-page-cursor
       - yesod-test

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: yesod-page-cursor
-version: 2.0.0.0
+version: 2.0.0.1
 github: "freckle/yesod-page-cursor"
 license: MIT
 author: Freckle Engineering

--- a/test/TestApp.hs
+++ b/test/TestApp.hs
@@ -1,5 +1,7 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}

--- a/yesod-page-cursor.cabal
+++ b/yesod-page-cursor.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 8dc3f8214e380e14ac9e103fd4cdff50f3186e9497536d2f654257e1e1d1072f
+-- hash: ed1d71a1dec91cc4071bac26beae857f1e47d70335d1f74fc4e37f25d5dfe1ce
 
 name:           yesod-page-cursor
 version:        2.0.0.0
@@ -34,13 +34,13 @@ library
   hs-source-dirs:
       src
   build-depends:
-      aeson
+      aeson <1.6
     , base >=4.7 && <5
     , bytestring
     , containers
     , http-link-header
     , network-uri
-    , text
+    , text >=1.2.3.2
     , unliftio
     , yesod-core
   default-language: Haskell2010
@@ -55,14 +55,14 @@ test-suite yesod-page-cursor-test
       test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      aeson
+      aeson <1.6
     , base >=4.7 && <5
     , bytestring
     , hspec
     , hspec-expectations-lifted
     , http-link-header
     , http-types
-    , lens
+    , lens <4.20
     , lens-aeson
     , monad-logger
     , mtl
@@ -70,11 +70,11 @@ test-suite yesod-page-cursor-test
     , persistent-sqlite
     , persistent-template
     , scientific
-    , text
+    , text >=1.2.3.2
     , time
     , unliftio
-    , unliftio-core
-    , wai-extra
+    , unliftio-core <0.3
+    , wai-extra <3.2
     , yesod
     , yesod-core
     , yesod-page-cursor


### PR DESCRIPTION
The middle commit is probably the only one worth some thought, so here is its
commit message:

> Add some dependency bounds
>
> This is a bit nuanced, and I'm not sure if it's the best approach, so here is
> some explanation:
>
> Managing dependency bounds manually is an error-prone pain. Stack supports a
> `--pvp-bounds` option to `sdist` (and `upload`, which uses it) to automate the
> process. It can add lower bounds, upper bounds, or both. It operates by
> looking at the version of every dependency in the resolver in use and sets a
> `>=` lower bound on that version and a `<` upper bound on the next major
> version.
>
> See https://www.fpcomplete.com/blog/2015/09/stack-pvp/
>
> We've decided to omit bounds in our committed source generally, and use the
> `--pvp-bounds both` option when releasing to Hackage. This is a conservative
> choice, adding tight bounds based on the latest LTS resolver, which is what we
> typically prefer in `stack.yaml`.
>
> Where this breaks down is when building the project, with those automated
> pvp-bounds, against `nightly`. Since the "next major" upper bound is relative
> to the current LTS resolver, it's likely that the nightly resolver will have a
> newer version and not build. Worse, you can't know this until you actually try
> to build from the package built with `sdist` -- since bounds aren't committed
> in `package.yaml`.
>
> The solution is simple but annoying: add back manual bounds that are more
> relaxed, which is what this commit does.
>
> Will this be just as error prone and annoying as not using the pvp-bounds
> option at all? Would using pvp-bounds upper or lower only work out better for
> us? I'm not sure, we'll see.

For reference, I use the following script to verify the package *as built with
the given bounds* will work in Stackage:

```sh

#!/bin/sh
set -eu

tmp=$(mktemp -d)
trap 'rm -rf -- "$tmp"' EXIT

stack build --dry-run
stack sdist --tar-dir "$tmp" --pvp-bounds both .

cd "$tmp"
tar xzf ./*.tar.gz

stack init --resolver nightly
stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
```