### PR TITLE
Re-order mkYesod/instance-Yesod

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,8 +1,12 @@
 # Changelog for yesod-cursor
 
-## [Unreleased](https://github.com/freckle/yesod-page-cursor/compare/v2.0.0.8...main)
+## [Unreleased](https://github.com/freckle/yesod-page-cursor/compare/v2.0.0.9...main)
 
 - None
+
+## [v2.0.0.9](https://github.com/freckle/yesod-page-cursor/compare/v2.0.0.8...v2.0.0.9)
+
+- Re-order declarations in TestApp, to build on GHC 9
 
 ## [v2.0.0.8](https://github.com/freckle/yesod-page-cursor/compare/v2.0.0.7...v2.0.0.8)
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,8 @@
 # Changelog for yesod-cursor
 
-## Unreleased changes
+## [Unreleased](https://github.com/freckle/yesod-page-cursor/compare/v2.0.0.8...main)
+
+- None
 
 ## [v2.0.0.8](https://github.com/freckle/yesod-page-cursor/compare/v2.0.0.7...v2.0.0.8)
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: yesod-page-cursor
-version: 2.0.0.8
+version: 2.0.0.9
 github: "freckle/yesod-page-cursor"
 license: MIT
 author: Freckle Engineering

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,10 @@
 resolver: lts-18.3
+
+extra-deps:
+  # for weeder
+  - dhall-1.37.1@sha256:447031286e8fe270b0baacd9cc5a8af340d2ae94bb53b85807bee93381ca5287,35080
+  - generic-lens-2.0.0.0@sha256:7409fa0ce540d0bd41acf596edd1c5d0c0ab1cd1294d514cf19c5c24e8ef2550,3866
+  - generic-lens-core-2.0.0.0@sha256:40b063c4a1399b3cdb19f2df1fae5a1a82f3313015c7c3e47fc23b8ef1b3e443,2913
+
 ghc-options:
   "$locals": -fwrite-ide-info

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,3 @@
-resolver: lts-17.1
+resolver: lts-18.3
 ghc-options:
   "$locals": -fwrite-ide-info

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 563098
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/17/1.yaml
-    sha256: 395775c03e66a4286f134d50346b0b6f1432131cf542886252984b4cfa5fef69
-  original: lts-17.1
+    size: 585603
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/3.yaml
+    sha256: 694573e96dca34db5636edb1fe6c96bb233ca0f9fb96c1ead1671cdfa9bd73e9
+  original: lts-18.3

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,7 +3,28 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages: []
+packages:
+- completed:
+    hackage: dhall-1.37.1@sha256:447031286e8fe270b0baacd9cc5a8af340d2ae94bb53b85807bee93381ca5287,35080
+    pantry-tree:
+      size: 305799
+      sha256: 623de5587e614ace2b6e2f908ccd4b4eec26db9cf29de45874bed8c0bdef2db8
+  original:
+    hackage: dhall-1.37.1@sha256:447031286e8fe270b0baacd9cc5a8af340d2ae94bb53b85807bee93381ca5287,35080
+- completed:
+    hackage: generic-lens-2.0.0.0@sha256:7409fa0ce540d0bd41acf596edd1c5d0c0ab1cd1294d514cf19c5c24e8ef2550,3866
+    pantry-tree:
+      size: 2470
+      sha256: 46ba160f0efc9c805eac6666f298f48dda899834b68c860f63641ce1f82db737
+  original:
+    hackage: generic-lens-2.0.0.0@sha256:7409fa0ce540d0bd41acf596edd1c5d0c0ab1cd1294d514cf19c5c24e8ef2550,3866
+- completed:
+    hackage: generic-lens-core-2.0.0.0@sha256:40b063c4a1399b3cdb19f2df1fae5a1a82f3313015c7c3e47fc23b8ef1b3e443,2913
+    pantry-tree:
+      size: 2201
+      sha256: 73f91636570c0e96044f655402ccbf6adba78d3a93f8d9ee97f3115bae096536
+  original:
+    hackage: generic-lens-core-2.0.0.0@sha256:40b063c4a1399b3cdb19f2df1fae5a1a82f3313015c7c3e47fc23b8ef1b3e443,2913
 snapshots:
 - completed:
     size: 585603

--- a/test/TestApp.hs
+++ b/test/TestApp.hs
@@ -69,6 +69,11 @@ instance ToJSON SomeAssignment where
 
 data Simple = Simple
 
+mkYesod "Simple" [parseRoutes|
+/some-route SomeR GET
+/some-route-link SomeLinkR GET
+|]
+
 instance Yesod Simple
 
 runDB'
@@ -80,11 +85,6 @@ runDB' f = withSqliteConn ":test:" $ runReaderT f
 instance YesodPersist Simple where
   type YesodPersistBackend Simple = SqlBackend
   runDB = runDB'
-
-mkYesod "Simple" [parseRoutes|
-/some-route SomeR GET
-/some-route-link SomeLinkR GET
-|]
 
 optionalParam :: Read a => MonadHandler m => Text -> m (Maybe a)
 optionalParam name = fmap (read . unpack) <$> lookupGetParam name

--- a/yesod-page-cursor.cabal
+++ b/yesod-page-cursor.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 666207ea21b5405d73f755be22985b3268aff5af02efe2a8e4f5e85822ab273c
+-- hash: 3bda58b69f6558a12242c7eb05e0c1e0d5040914fd9694c380a838bbdcfcdf11
 
 name:           yesod-page-cursor
-version:        2.0.0.8
+version:        2.0.0.9
 description:    Cursor based pagination for Yesod
 homepage:       https://github.com/freckle/yesod-page-cursor#readme
 bug-reports:    https://github.com/freckle/yesod-page-cursor/issues


### PR DESCRIPTION
`Yesod` has a superclass constraint on `RenderRoute`, which is provided by
`mkYesod` Template Haskell. It appears that GHC 9 (just hit `nightly`) requires
the TH that generates that class appear before the instance that needs it.

I honestly would've always expected that to be the case, but this code was fine
before. Oh well.

Fixes #29.