### PR TITLE
Add absolute version of withPage{,Link}

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,9 @@ Primer: [No Offset](https://use-the-index-luke.com/no-offset)
 ```hs
 getSomeR :: Handler Value
 getSomeR = do
-  let
-    parseParams =
-      (,) <$> Param.required "teacherId" <*> Param.optional "courseId"
-  page <- withPage 100 entityPage parseParams $ \Cursor {..} -> do
+  teacherId <- Param.required "teacherId"
+  mCourseId <- Param.optional "courseId"
+  page <- withPageAbsolute 100 entityKey $ \Cursor {..} -> do
     let (teacherId, mCourseId) = cursorParams
     fmap (sort cursorPosition) . runDB $ selectList
       (catMaybes
@@ -43,16 +42,9 @@ getSomeR = do
 like:
 
 ```hs
-createdAtPage = PageConfig
-  { makePosition = \x ->
-      (entityKey x, someAsssignmentCreatedAt $ entityVal x)
-  , baseDomain = Nothing
-  }
-
 getSortedSomeR :: Handler Value
 getSortedSomeR = do
-  let parseParams = pure ()
-  page <- withPage 100 createdAtPage parseParams $ \Cursor {..} -> do
+  page <- withPageAbsolute 100 $ \Cursor {..} -> do
     fmap (sort cursorPosition) . runDB $ selectList
       (whereClause cursorPosition)
       [ LimitTo $ fromMaybe 100 cursorLimit
@@ -91,9 +83,9 @@ retrieve the next page.
 ```sh
 $ curl 'some-rest.com/endpoint?limit=3'
 {
-  "first": : "some-rest.com/endpoint?next=eyJsYXN0UG9zaXRpb24iOjMsInBhcmFtcyI6WzEsbnVsbF0sImxpbWl0IjozfQ==",
+  "first": : "https://some-rest.com/endpoint?next=eyJsYXN0UG9zaXRpb24iOjMsInBhcmFtcyI6WzEsbnVsbF0sImxpbWl0IjozfQ==",
   "previous": null,
-  "next": "some-rest.com/endpoint?next=eyJsYXN0UG9zaXRpb24iOjMsInBhcmFtcyI6WzEsbnVsbF0sImxpbWl0IjozfQ==",
+  "next": "https://some-rest.com/endpoint?next=eyJsYXN0UG9zaXRpb24iOjMsInBhcmFtcyI6WzEsbnVsbF0sImxpbWl0IjozfQ==",
   "data": [...]
 }
 ```
@@ -103,9 +95,9 @@ The link can be used to retrieve the next page.
 ```sh
 $ curl 'some-rest.com/endpoint?next=eyJsYXN0UG9zaXRpb24iOjMsInBhcmFtcyI6WzEsbnVsbF0sImxpbWl0IjozfQ=='
 {
-  "first": : "some-rest.com/endpoint?next=eyJsYXN0UG9zaXRpb24iOjMsInBhcmFtcyI6WzEsbnVsbF0sImxpbWl0IjozfQ==",
-  "previous": "some-rest.com/endpoint?next=eyJsYXN0UG9zaXRpb24iOjMsInBhcmFtcyI6WzEsbnVsbF0sImxpbWl0IjozfQ==",
-  "next": "some-rest.com/endpoint?next=eyJsYXN0UG9zaXRpb24iOjMsInBhcmFtcyI6WzEsbnVsbF0sImxpbWl0IjozfQ==",
+  "first": : "https://some-rest.com/endpoint?next=eyJsYXN0UG9zaXRpb24iOjMsInBhcmFtcyI6WzEsbnVsbF0sImxpbWl0IjozfQ==",
+  "previous": "https://some-rest.com/endpoint?next=eyJsYXN0UG9zaXRpb24iOjMsInBhcmFtcyI6WzEsbnVsbF0sImxpbWl0IjozfQ==",
+  "next": "https://some-rest.com/endpoint?next=eyJsYXN0UG9zaXRpb24iOjMsInBhcmFtcyI6WzEsbnVsbF0sImxpbWl0IjozfQ==",
   "data": [...]
 }
 ```
@@ -115,8 +107,8 @@ If no pages remain then no link is returned
 ```sh
 $ curl 'some-rest.com/endpoint?next=eyJsYXN0UG9zaXRpb24iOjMsInBhcmFtcyI6WzEsbnVsbF0sImxpbWl0IjozfQ=='
 {
-  "first": : "some-rest.com/endpoint?next=eyJsYXN0UG9zaXRpb24iOjMsInBhcmFtcyI6WzEsbnVsbF0sImxpbWl0IjozfQ==",
-  "previous": "some-rest.com/endpoint?next=eyJsYXN0UG9zaXRpb24iOjMsInBhcmFtcyI6WzEsbnVsbF0sImxpbWl0IjozfQ==",
+  "first": : "https://some-rest.com/endpoint?next=eyJsYXN0UG9zaXRpb24iOjMsInBhcmFtcyI6WzEsbnVsbF0sImxpbWl0IjozfQ==",
+  "previous": "https://some-rest.com/endpoint?next=eyJsYXN0UG9zaXRpb24iOjMsInBhcmFtcyI6WzEsbnVsbF0sImxpbWl0IjozfQ==",
   "next": null,
   "data": [...]
 }

--- a/src/Yesod/Page/RenderedRoute.hs
+++ b/src/Yesod/Page/RenderedRoute.hs
@@ -8,6 +8,7 @@ module Yesod.Page.RenderedRoute
   ( RenderedRoute
   , renderedRouteLink
   , getRenderedRoute
+  , getRenderedRouteAbsolute
   , updateQueryParameter
   )
 where
@@ -15,23 +16,31 @@ where
 import Data.Aeson
 import Data.Map (Map)
 import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
 import Data.Text (Text, intercalate, pack, unpack)
 import Network.HTTP.Link.Compat
-import Network.URI (URI(..), escapeURIString, isUnescapedInURIComponent)
+import Network.URI
+  (URI(..), escapeURIString, isUnescapedInURIComponent, parseAbsoluteURI)
 import UnliftIO (throwString)
 import Yesod.Core
   ( HandlerSite
   , MonadHandler
   , RenderRoute
+  , Yesod
+  , approot
+  , getApprootText
   , getCurrentRoute
   , getRequest
+  , getYesod
   , renderRoute
   , reqGetParams
+  , waiRequest
   )
 
 -- | Information about a relative Route with query string
 data RenderedRoute = RenderedRoute
-  { renderedRoutePath :: [Text]
+  { renderedApproot :: Text
+  , renderedRoutePath :: [Text]
   , renderedRouteQuery :: [(Text, Text)]
   }
 
@@ -45,8 +54,8 @@ renderedRouteLink rel = flip linkURI [(Rel, rel)] . renderedRouteURI
 -- | Convert a @'RenderedRoute'@ into a (relative) @'URI'@
 renderedRouteURI :: RenderedRoute -> URI
 renderedRouteURI RenderedRoute {..} = URI
-  { uriScheme = ""
-  , uriAuthority = Nothing
+  { uriScheme = scheme
+  , uriAuthority = authority
   , uriPath = unpack $ "/" <> intercalate "/" renderedRoutePath
   , uriQuery = unpack $ query renderedRouteQuery
   , uriFragment = ""
@@ -56,6 +65,10 @@ renderedRouteURI RenderedRoute {..} = URI
   query qs = "?" <> intercalate "&" (parts qs)
   parts = map $ \(k, v) -> k <> "=" <> escape v
   escape = pack . escapeURIString isUnescapedInURIComponent . unpack
+
+  (scheme, authority) = fromMaybe ("", Nothing) $ do
+    uri <- parseAbsoluteURI $ unpack renderedApproot
+    pure (uriScheme uri, uriAuthority uri)
 
 -- | Get the current route as a @'RenderedRoute'@
 getRenderedRoute
@@ -68,7 +81,29 @@ getRenderedRoute = do
   let (path, _query) = renderRoute route
   query <- reqGetParams <$> getRequest
 
-  pure $ RenderedRoute { renderedRoutePath = path, renderedRouteQuery = query }
+  pure $ RenderedRoute
+    { renderedApproot = ""
+    , renderedRoutePath = path
+    , renderedRouteQuery = query
+    }
+
+getRenderedRouteAbsolute
+  :: (MonadHandler m, Yesod (HandlerSite m), RenderRoute (HandlerSite m))
+  => m RenderedRoute
+getRenderedRouteAbsolute = do
+  route <- maybe (throwString "no route") pure =<< getCurrentRoute
+
+  -- When I just use _query, it's always empty. Why would renderRoute return
+  -- this tuple if the Route value (apparently) never has the query information?
+  let (path, _query) = renderRoute route
+  query <- reqGetParams <$> getRequest
+  root <- getApprootText approot <$> getYesod <*> waiRequest
+
+  pure $ RenderedRoute
+    { renderedApproot = root
+    , renderedRoutePath = path
+    , renderedRouteQuery = query
+    }
 
 -- | Update a single query parameter and preserve the rest
 --

--- a/test/TestApp.hs
+++ b/test/TestApp.hs
@@ -41,9 +41,10 @@ import Database.Persist.TH
 import GHC.Generics (Generic)
 import Network.HTTP.Types.Status (status400)
 import Yesod
-  ( MonadHandler
+  ( Approot(..)
+  , MonadHandler
   , MonadUnliftIO
-  , Yesod
+  , Yesod(approot)
   , YesodPersist
   , YesodPersistBackend
   , lookupGetParam
@@ -71,10 +72,13 @@ data Simple = Simple
 
 mkYesod "Simple" [parseRoutes|
 /some-route SomeR GET
+/some-route-absolute SomeAbsoluteR GET
 /some-route-link SomeLinkR GET
+/some-route-link-absolute SomeLinkAbsoluteR GET
 |]
 
-instance Yesod Simple
+instance Yesod Simple where
+  approot = ApprootStatic "http://localhost:3000"
 
 runDB'
   :: (MonadUnliftIO m, MonadLogger m, MonadLoggerIO m)
@@ -98,8 +102,14 @@ requireParam name = maybe badRequest pure =<< optionalParam name
 getSomeR :: Handler Value
 getSomeR = makePaginationRoute withPage
 
+getSomeAbsoluteR :: Handler Value
+getSomeAbsoluteR = makePaginationRoute withPageAbsolute
+
 getSomeLinkR :: Handler Value
 getSomeLinkR = makePaginationRoute withPageLink
+
+getSomeLinkAbsoluteR :: Handler Value
+getSomeLinkAbsoluteR = makePaginationRoute withPageLinkAbsolute
 
 type Pagination m f a
   = Int


### PR DESCRIPTION
Returning absolute pagination links is almost always what you want.
Clients shouldn't need to maintain their own state to supply the domain
when making follow-up calls to later pages based on the responses they
have. Including absolute links makes this trivial.

However, we want to handle the transition carefully since any clients in
use today will probably break if they're expecting relative links and
suddenly start getting absolute ones. Therefore, we're making it opt-in
on the part of our library users so they can manage their own clients'
expectations. Therefore, we're adding "Absolute"-suffixed versions of
our two main functions.

As for implementation, I chose to completely duplicate the code-path top
to bottom. This was the only way I could find to avoid adding the new
Yesod class-constraint to the existing functions (and thus triggering a
major version bump). Eventually, the non-Absolute versions will go away,
resolving the duplication naturally.
